### PR TITLE
Added error name and message to output

### DIFF
--- a/jstd-adapter-template.js
+++ b/jstd-adapter-template.js
@@ -38,6 +38,7 @@
             log.push(testResult.log);
         if (testResult.message != "" && testResult.message != "[]") {
             var error = JSON.parse(testResult.message)[0];
+            log.push(error.name + ": " + error.message);
             log.push(error.stack);
         }
         karma.result({

--- a/jstd-adapter.js
+++ b/jstd-adapter.js
@@ -7635,6 +7635,7 @@ jstestdriver.plugins.TestCaseManagerPlugin.prototype.getTestRunsConfigurationFor
             log.push(testResult.log);
         if (testResult.message != "" && testResult.message != "[]") {
             var error = JSON.parse(testResult.message)[0];
+            log.push(error.name + ": " + error.message);
             log.push(error.stack);
         }
         karma.result({


### PR DESCRIPTION
When a test fails, the error name and message were not shown. This change adds these to the log output.