### PR TITLE
Fixed 'window is undefined' error when adapter is installed via npm, attempt #2

### DIFF
--- a/jstd-adapter.js
+++ b/jstd-adapter.js
@@ -1,4 +1,6 @@
-
+// Prevent errors when Karma automatically loads the file from node_modules.
+// Indentation is not correct to prevent long Git diff.
+if (typeof window !== 'undefined') {
 
 /*
  * Copyright 2009 Google Inc.
@@ -7682,3 +7684,5 @@ jstestdriver.plugins.TestCaseManagerPlugin.prototype.getTestRunsConfigurationFor
         return value;
     });
 })(window);
+
+}


### PR DESCRIPTION
Fixes the issue with smaller Git diff than in #3.